### PR TITLE
Don't escape "/" in strings

### DIFF
--- a/main.c
+++ b/main.c
@@ -84,6 +84,8 @@ int TreeView_SetItemText(HWND hTreeWnd, HTREEITEM hItem, TCHAR* text);
 int ListView_AddColumn(HWND hListWnd, TCHAR* colName);
 int Header_GetItemText(HWND hWnd, int i, TCHAR* pszText, int cchTextMax);
 
+json_set_escape_slashes(0);
+
 BOOL APIENTRY DllMain (HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
 	return TRUE;
 }


### PR DESCRIPTION
I didn't try to compile this though, just patched `1` to `0` in the dll manually, here's the result:

Before | After
-|-
![image](https://user-images.githubusercontent.com/1310400/138545044-5ce7e69f-ebf8-4ce7-9f26-716f78ebd0a1.png) | ![image](https://user-images.githubusercontent.com/1310400/138544910-62f22901-c71c-4297-8ff3-fbc25e734662.png)